### PR TITLE
README.md: Fix link to kube-prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ $ ks apply default
 
 ## Using kube-prometheus
 
-See the kube-prometheus docs for [instructions on how to use mixins with kube-prometheus](https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/README.md#kube-prometheus).
+See the kube-prometheus docs for [instructions on how to use mixins with kube-prometheus](https://github.com/coreos/kube-prometheus#kube-prometheus).
 
 ## Customising the mixin
 


### PR DESCRIPTION
kube-prometheus moved to its own repo, this adjusts the link to point to the correct README.