### PR TITLE
Add Spinnaker & Cert Manager mixins

### DIFF
--- a/directory.md
+++ b/directory.md
@@ -7,6 +7,7 @@
 | [Alertmanager](https://github.com/prometheus/alertmanager) | [prometheus/alertmanager/doc/alertmanager-mixin](https://github.com/prometheus/alertmanager/pull/1629) (pending PR) |
 | [Etcd](https://coreos.com/etcd/) | [etcd-io/etcd/Documentation/etcd-mixin](https://github.com/etcd-io/etcd/tree/master/Documentation/etcd-mixin) |
 | [Ceph](https://ceph.com/) | [ceph/ceph-mixin](https://github.com/ceph/ceph-mixins) |
+| [Cert Manager](https://gitlab.com/uneeq-oss/cert-manager-mixin) | [cert-manager-mixin](https://gitlab.com/uneeq-oss/cert-manager-mixin) |
 | [Gluster](https://redhatstorage.redhat.com/products/glusterfs/) | [gluster/gluster-mixin](https://github.com/gluster/gluster-mixins) |
 | [Hashicorp Consul](https://www.consul.io/) | [grafana/jsonnet-libs/consul-mixin](https://github.com/grafana/jsonnet-libs/tree/master/consul-mixin) |
 | [Jaeger](https://www.jaegertracing.io/) | [grafana/jsonnet-libs/jaeger-mixin](https://github.com/grafana/jsonnet-libs/tree/master/jaeger-mixin) |
@@ -16,3 +17,4 @@
 | [Node Exporter](https://github.com/prometheus/node_exporter) | [prometheus/node-exporter/docs/node-mixin](https://github.com/prometheus/node_exporter/tree/master/docs/node-mixin) |
 | [Prometheus](https://prometheus.io) | [prometheus/prometheus/docs/prometheus-mixin](https://github.com/prometheus/prometheus/tree/master/documentation/prometheus-mixin) |
 | [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) | [contrib/prometheus-mixin](https://github.com/bitnami-labs/sealed-secrets/tree/master/contrib/prometheus-mixin) |
+| [Spinnaker](https://gitlab.com/uneeq-oss/spinnaker-mixin) | [spinnaker-mixin](https://gitlab.com/uneeq-oss/spinnaker-mixin) |


### PR DESCRIPTION
Not sure if this repo is still in use given https://github.com/monitoring-mixins/website/ but figure might as well PR a couple mixin's in.