### PR TITLE
Update docs and provide an example Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: prometheus_alerts.yaml prometheus_rules.yaml dashboards_out
+
+prometheus_alerts.yaml: mixin.libsonnet
+	@mkdir -p out/
+	mixtool generate alerts -a out/prometheus_alerts.yaml -y $<
+
+prometheus_rules.yaml: mixin.libsonnet
+	@mkdir -p out/
+	mixtool generate rules -r out/prometheus_rules.yaml -y $<
+
+dashboards_out: mixin.libsonnet
+	@mkdir -p out/dashboards
+	mixtool generate dashboards -d out/dashboards $<
+
+all: mixin.libsonnet
+	@mkdir -p out/
+	mixtool generate all -d out/dashboards -r out/prometheus_rules.yaml -a out/prometheus_alerts.yaml -y  $<


### PR DESCRIPTION
Update docs to add details to mixin creation and usage, removing the use of ksonnet in favor of grizzly, and providing a Makefile that uses mixtool to generate objects from the mixin.